### PR TITLE
Implement getting the entities in the core column

### DIFF
--- a/src/feature_extraction/bag_of_entities.py
+++ b/src/feature_extraction/bag_of_entities.py
@@ -28,7 +28,7 @@ def get_dbpedia_entities(cell):
         return list(types)
 
 
-def get_content_entities(table):
+def get_core_column_entities(table):
     if len(table) == 0:
         return []
     column_entities = [[] for x in range(len(table[0]))]
@@ -55,4 +55,4 @@ for i in range(loader.start, loader.end):
         if 'secondTitle' in loader.currentData[tableID]:
             print(loader.currentData[tableID]['secondTitle'])
         if 'data' in loader.currentData[tableID]:
-            print(get_content_entities(loader.currentData[tableID]['data']))
+            print(get_core_column_entities(loader.currentData[tableID]['data']))


### PR DESCRIPTION
Uses a SPARQL query to get entities from DBpedia

Not quite sure what data we need, so for now this just gets the top 10 rdf:type values for a given entity
Example for this entity: http://dbpedia.org/page/Fr%C3%A9d%C3%A9rick_Bousquet
It returns:
```
[
        'http://www.w3.org/2002/07/owl#Thing',
        'http://xmlns.com/foaf/0.1/Person',
        'http://dbpedia.org/ontology/Person',
        'http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Agent',
        'http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#NaturalPerson',
        'http://www.wikidata.org/entity/Q10843402',
        'http://www.wikidata.org/entity/Q215627',
        'http://www.wikidata.org/entity/Q24229398',
        'http://www.wikidata.org/entity/Q5',
        'http://dbpedia.org/ontology/Agent',
        'http://dbpedia.org/ontology/Athlete',
        'http://dbpedia.org/ontology/Swimmer',
        'http://schema.org/Person',
        'http://dbpedia.org/class/yago/WikicatFreestyleSwimmers',
        'http://dbpedia.org/class/yago/WikicatFrenchSwimmers',
        'http://dbpedia.org/class/yago/WikicatSwimmersAtThe2000SummerOlympics',
        'http://dbpedia.org/class/yago/WikicatSwimmersAtThe2004SummerOlympics',
        'http://dbpedia.org/class/yago/WikicatSwimmersAtThe2008SummerOlympics',
        'http://dbpedia.org/class/yago/Athlete109820263',
        'http://dbpedia.org/class/yago/CausalAgent100007347'
]
```